### PR TITLE
feat: adds duplicated status to check match eligibility

### DIFF
--- a/src/lib/checkMatchEligibility.ts
+++ b/src/lib/checkMatchEligibility.ts
@@ -5,6 +5,7 @@ import {
 	statusOnGoingMatch,
 	statusSupportRequestisAlreadyInQueue,
 	statusSupportRequestOngoingSocialWorker,
+	statusSupportRequestDuplicated
 } from "@/lib";
 
 const payloadSchema = Yup.object({
@@ -91,6 +92,7 @@ export default async function checkMatchEligibility(
 	const statusOngoingSupportRequest: string[] = [
 		...statusSupportRequestisAlreadyInQueue,
 		...statusSupportRequestOngoingSocialWorker,
+		...statusSupportRequestDuplicated
 	];
 	const hasOngoingSupport = statusOngoingSupportRequest.includes(
 		supportRequest.status

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -135,6 +135,9 @@ export const statusSupportRequestisAlreadyInQueue = [
 	SupportRequestsStatus.waiting_for_match,
 	SupportRequestsStatus.waiting_for_match_with_priority,
 ];
+export const statusSupportRequestDuplicated = [
+	SupportRequestsStatus.duplicated
+];
 
 export const ZENDESK_SUBDOMAIN = process.env["ZENDESK_SUBDOMAIN"];
 export const ZENDESK_API_USER = `${process.env["ZENDESK_API_USER"]}/token`;


### PR DESCRIPTION
Esse PR adiciona o status `duplicated` à lista de status que indicam que o support_request já está em andamento